### PR TITLE
解决CF信息无法获取导致的每日比赛不工作

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 __pycache__
+test.py

--- a/codeforces.py
+++ b/codeforces.py
@@ -7,6 +7,7 @@ from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util import Retry
 
 import DB
+import methods
 
 url_cf = "http://codeforces.com/api"
 RES = requests.session()
@@ -41,9 +42,13 @@ def get_codeforces_contests():
     type:比赛类型，status:比赛状态，relative_time: ，id:比赛的id用于拼接比赛地址}
     """
     response = RES.get(url=url_cf + "/contest.list")
+    cnt = 0
     while response.status_code != 200:
         response = RES.get(url=url_cf + "/contest.list")
         time.sleep(0.3)
+        cnt += 1
+        if cnt > 10:
+            return 'ERROR:' + str(response.status_code)
     res = response.json().get("result")
     contests = []
     for i in res:
@@ -91,6 +96,8 @@ def message_codeforces_daily():
     # contests = cfdeldiv1(contests)
     if len(contests) == 0:
         return "NULL"
+    if "ERROR" in contests:
+        return contests
     flag = False
     for i in contests[::-1]:
         timet = i['begin_time'].split()
@@ -116,6 +123,8 @@ def message_codeforces_all():
     if len(contests) == 0:
         message += "[空空如也]\t\t\n\n"
         return message
+    if "ERROR" in contests:
+        return contests
     for i in contests[::-1]:
         message += message_formate(i)
         message += "\n"

--- a/methods.py
+++ b/methods.py
@@ -130,12 +130,17 @@ def autosendmessage(group_id, testgroup_id):
 
     message = "今日比赛:\n"
     flag = 0
+    error = 0
 
     # 调用 codeforces 的函数拼接今日的cf比赛信息
     message_temp = message_codeforces_daily()
-    if message_temp != "NULL":
-        flag += 1
-        message += "\n" + message_temp
+    if "ERROR" in message_temp:
+        error = 1
+        message += "CF比赛无法获取\n"+message_temp
+    else:
+        if message_temp != "NULL":
+            flag += 1
+            message += "\n" + message_temp
 
     # 调用 atcoder 的函数拼接今日的at比赛信息
     message_temp = message_atcoder_daily()
@@ -153,9 +158,13 @@ def autosendmessage(group_id, testgroup_id):
     if flag != 0:
         sendGroupMessage(group_id, message)
     else:
-        message = "今日无比赛，近日的CF比赛如下：\n\n"
-        message += message_codeforces_all()
-        sendGroupMessage(testgroup_id, message)
+        if error:
+            message = "CF比赛信息无法获取\n" + message_codeforces_all() + "\n"
+            sendGroupMessage(testgroup_id, message)
+        else:
+            message = "今日无比赛，近日的CF比赛如下：\n\n"
+            message += message_codeforces_all()
+            sendGroupMessage(testgroup_id, message)
 
     # 释放文件锁
     f.close()


### PR DESCRIPTION
暂时解决cf因为不能访问导致的无法发送数据。爬取10次，并且在发送的信息中将这错误体现出来